### PR TITLE
Some board-related user-friendliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run this command in your terminal to install the dependencies at once
 #### 🐍 As a Python File
 
 - Download / Clone this repository
-- `python schemix\main.py` (Windows or other NT-based system) and `python schemix/main.py` (UNIX-like system)
+- `python schemix\main.py` (Windows or other NT-based system) and `python3 schemix/main.py` (UNIX-like system)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Let's set up Schemix on your PC!
 
 Run this command in your terminal to install the dependencies at once
   ```sh
-  python install_deps.py
+  python install_deps.py # Windows NT-based system
+  python3 install_deps.py # UNIX-like system
   ```
 
 ### Installation

--- a/build.py
+++ b/build.py
@@ -13,7 +13,7 @@ def run_pyinstaller():
                 'pyinstaller',
                 main_script,
                 '-w',  # Makes it windowed
-                '--name', '"Schemix"',
+                '--name', 'Schemix',
                 '--icon=icon.ico'
             ]
         else:

--- a/schemix/core/MiscWidgets.py
+++ b/schemix/core/MiscWidgets.py
@@ -17,7 +17,7 @@ class BoardSelector(QWidget):
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(QLabel("No board found. Create a board to continue."))
         create_button = QPushButton("➕ Create/Select Board")
-        create_button.clicked.connect(MainWindow.create_board)
+        create_button.clicked.connect(self.create_board)
         self.layout().addWidget(create_button)
 
     def create_board(self):

--- a/schemix/core/MiscWidgets.py
+++ b/schemix/core/MiscWidgets.py
@@ -26,4 +26,4 @@ class BoardSelector(QWidget):
         # board, ok = QInputDialog.getText(self, "Create Board", f"{boardList}\n\nEnter board name:")
         board = simpledialog.askstring("Create or Load Board", f"Existing Boards:\n{boardList}\n\nTo load an existing board, simply enter its exact name. To create a blank/new board, simply enter the name of the new board.\n\nEnter board name:")
         if board:
-            self.create_board(board)
+            self.create_board_callback(board)

--- a/schemix/core/MiscWidgets.py
+++ b/schemix/core/MiscWidgets.py
@@ -16,7 +16,7 @@ class BoardSelector(QWidget):
         self.create_board_callback = create_board_callback
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(QLabel("No board found. Create a board to continue."))
-        create_button = QPushButton("➕ Create Board")
+        create_button = QPushButton("➕ Create/Select Board")
         create_button.clicked.connect(MainWindow.create_board)
         self.layout().addWidget(create_button)
 

--- a/schemix/core/MiscWidgets.py
+++ b/schemix/core/MiscWidgets.py
@@ -1,5 +1,5 @@
 import re
-
+import tkinter as tk
 from PyQt6.QtWidgets import (
     QVBoxLayout, QWidget, QLabel, QInputDialog, QPushButton
 )

--- a/schemix/core/MiscWidgets.py
+++ b/schemix/core/MiscWidgets.py
@@ -17,10 +17,12 @@ class BoardSelector(QWidget):
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(QLabel("No board found. Create a board to continue."))
         create_button = QPushButton("➕ Create Board")
-        create_button.clicked.connect(self.create_board)
+        create_button.clicked.connect(MainWindow.create_board)
         self.layout().addWidget(create_button)
 
     def create_board(self):
-        board, ok = QInputDialog.getText(self, "Create Board", "Enter board name:")
-        if ok and board:
-            self.create_board_callback(board)
+        boardList = "\n".join(os.path.basename(str(p)) for p in Path(self.base_dir).iterdir())
+        # board, ok = QInputDialog.getText(self, "Create Board", f"{boardList}\n\nEnter board name:")
+        board = simpledialog.askstring("Create or Load Board", f"Existing Boards:\n{boardList}\n\nTo load an existing board, simply enter its exact name. To create a blank/new board, simply enter the name of the new board.\n\nEnter board name:")
+        if board:
+            self.create_board(board)

--- a/schemix/core/MiscWidgets.py
+++ b/schemix/core/MiscWidgets.py
@@ -1,5 +1,4 @@
 import re
-import tkinter as tk
 from PyQt6.QtWidgets import (
     QVBoxLayout, QWidget, QLabel, QInputDialog, QPushButton
 )

--- a/schemix/core/MiscWidgets.py
+++ b/schemix/core/MiscWidgets.py
@@ -4,6 +4,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout, QWidget, QLabel, QInputDialog, QPushButton
 )
 from pint import UnitRegistry
+from pathlib import Path
 
 ureg = UnitRegistry()
 

--- a/schemix/core/MiscWidgets.py
+++ b/schemix/core/MiscWidgets.py
@@ -12,8 +12,9 @@ UNIT_PATTERN = re.compile(r"\b(\d+(?:\.\d+)?)\s?(km/h|m/s|kg|g|L|ml|N|km|m|cm|mm
 
 
 class BoardSelector(QWidget):
-    def __init__(self, create_board_callback):
+    def __init__(self, create_board_callback, main_window):
         super().__init__()
+        self.main_window = main_window
         self.create_board_callback = create_board_callback
         self.setLayout(QVBoxLayout())
         self.layout().addWidget(QLabel("No board found. Create a board to continue."))
@@ -22,8 +23,4 @@ class BoardSelector(QWidget):
         self.layout().addWidget(create_button)
 
     def create_board(self):
-        boardList = "\n".join(os.path.basename(str(p)) for p in Path(self.base_dir).iterdir())
-        # board, ok = QInputDialog.getText(self, "Create Board", f"{boardList}\n\nEnter board name:")
-        board = simpledialog.askstring("Create or Load Board", f"Existing Boards:\n{boardList}\n\nTo load an existing board, simply enter its exact name. To create a blank/new board, simply enter the name of the new board.\n\nEnter board name:")
-        if board:
-            self.create_board_callback(board)
+        self.main_window.prompt_create_board()

--- a/schemix/core/MiscWidgets.py
+++ b/schemix/core/MiscWidgets.py
@@ -1,6 +1,6 @@
 import re
 from PyQt6.QtWidgets import (
-    QVBoxLayout, QWidget, QLabel, QInputDialog, QPushButton
+    QVBoxLayout, QWidget, QLabel, QPushButton
 )
 from pint import UnitRegistry
 

--- a/schemix/core/MiscWidgets.py
+++ b/schemix/core/MiscWidgets.py
@@ -3,7 +3,6 @@ from PyQt6.QtWidgets import (
     QVBoxLayout, QWidget, QLabel, QInputDialog, QPushButton
 )
 from pint import UnitRegistry
-from pathlib import Path
 
 ureg = UnitRegistry()
 

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -265,7 +265,7 @@ class MainWindow(QMainWindow):
                     self.load_chapters()
 
     def prompt_create_board(self):
-        boardList = "\n".join(str(p) for p in Path(self.base_dir).iterdir())
+        boardList = "\n".join(os.path.basename(str(p)) for p in Path(self.base_dir).iterdir())
         # board, ok = QInputDialog.getText(self, "Create Board", f"{boardList}\n\nEnter board name:")
         board = simpledialog.askstring("Create Board", f"Existing Boards:\n{boardList}\n\nEnter board name:")
         if board:

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -284,6 +284,14 @@ class MainWindow(QMainWindow):
             shutil.rmtree(self.board_dir, ignore_errors=True)
             self.board_dir = None
             self.check_or_create_board()
+    
+    def show_boards_in_fm(self):
+        if platform.system() == "Windows":
+            os.system(f"explorer {self.base_dir}")
+        elif platform.system() == "Darwin":
+            os.system(f"open -a Finder {self.base_dir}")
+        elif platform.system() == "Linux":
+            os.system(f"xdg-open {self.base_dir}")
 
     def get_current_editor(self):
         return self.tab_widget.currentWidget()
@@ -379,6 +387,10 @@ class MainWindow(QMainWindow):
         delete_board_action = QAction("🗑️ Delete Board", self)
         delete_board_action.triggered.connect(self.delete_current_board)
         file_menu.addAction(delete_board_action)
+
+        show_boards_action = QAction("📂 Show Boards in File Manager", self)
+        show_boards_action.triggered.connect(self.show_boards_in_fm)
+        file_menu.addAction(show_boards_action)
 
         view_menu = self.menuBar().addMenu("View")
         toggle_subjects_dock = QAction("Toggle Subjects", self)

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -267,7 +267,7 @@ class MainWindow(QMainWindow):
     def prompt_create_board(self):
         boardList = "\n".join(os.path.basename(str(p)) for p in Path(self.base_dir).iterdir())
         # board, ok = QInputDialog.getText(self, "Create Board", f"{boardList}\n\nEnter board name:")
-        board = simpledialog.askstring("Create Board", f"Existing Boards:\n{boardList}\n\nTo load an existing board, simply enter its exact name.\n\nEnter board name:")
+        board = simpledialog.askstring("Create or Load Board", f"Existing Boards:\n{boardList}\n\nTo load an existing board, simply enter its exact name. To create a blank/new board, simply enter the name of the new board.\n\nEnter board name:")
         if board:
             self.create_board(board)
 

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -267,7 +267,7 @@ class MainWindow(QMainWindow):
     def prompt_create_board(self):
         boardList = "\n".join(os.path.basename(str(p)) for p in Path(self.base_dir).iterdir())
         # board, ok = QInputDialog.getText(self, "Create Board", f"{boardList}\n\nEnter board name:")
-        board = simpledialog.askstring("Create Board", f"Existing Boards:\n{boardList}\n\nEnter board name:")
+        board = simpledialog.askstring("Create Board", f"Existing Boards:\n{boardList}\n\nTo load an existing board, simply enter its exact name.\n\nEnter board name:")
         if board:
             self.create_board(board)
 

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -25,6 +25,8 @@ ureg = UnitRegistry()
 
 UNIT_PATTERN = re.compile(r"\b(\d+(?:\.\d+)?)\s?(km/h|m/s|kg|g|L|ml|N|km|m|cm|mm|ft|in|lb|gal)\b", re.IGNORECASE)
 
+class platformError(Exception):
+    pass
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -292,6 +294,8 @@ class MainWindow(QMainWindow):
             os.system(f"open -a Finder {self.base_dir}")
         elif platform.system() == "Linux":
             os.system(f"xdg-open {self.base_dir}")
+        else:
+            raise platformError("Your operating system does not support this feature (yet)")
 
     def get_current_editor(self):
         return self.tab_widget.currentWidget()

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -44,6 +44,7 @@ class MainWindow(QMainWindow):
         self.base_dir = local_app_data
         os.makedirs(self.base_dir, exist_ok=True)
         self.board_dir = None
+        board_selector = MiscWidgets.BoardSelector(self.create_board, self)
 
         self.setWindowIcon(QIcon("assets/icon.png"))
 
@@ -534,7 +535,7 @@ class MainWindow(QMainWindow):
             boards.sort(key=lambda d: os.path.getmtime(os.path.join(self.base_dir, d)), reverse=True)
             self.load_board(boards[0])
         else:
-            board_selector = MiscWidgets.BoardSelector(self.create_board)
+            board_selector = MiscWidgets.BoardSelector(self.create_board, self)
             self.central_stack.addWidget(board_selector)
             self.central_stack.setCurrentWidget(board_selector)
 

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -371,7 +371,7 @@ class MainWindow(QMainWindow):
         save_action.triggered.connect(self.save_current_chapter)
         file_menu.addAction(save_action)
 
-        add_board_action = QAction("➕ Add Board", self)
+        add_board_action = QAction("➕ Add/Select Board", self)
         add_board_action.triggered.connect(self.prompt_create_board)
         file_menu.addAction(add_board_action)
 

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -5,6 +5,8 @@ import sys
 import time
 from pathlib import Path
 import platform
+import tkinter as tk
+from tkinter import simpledialog
 
 import qdarktheme
 from PyQt6.QtCore import Qt, QUrl
@@ -263,8 +265,10 @@ class MainWindow(QMainWindow):
                     self.load_chapters()
 
     def prompt_create_board(self):
-        board, ok = QInputDialog.getText(self, "Create Board", "Enter board name:")
-        if ok and board:
+        boardList = "\n".join(str(p) for p in Path(self.base_dir).iterdir())
+        # board, ok = QInputDialog.getText(self, "Create Board", f"{boardList}\n\nEnter board name:")
+        board = simpledialog.askstring("Create Board", f"Existing Boards:\n{boardList}\n\nEnter board name:")
+        if board:
             self.create_board(board)
 
     def delete_current_board(self):


### PR DESCRIPTION
Changes:
1. Shows user their existing boards and instructs them on how to load them via special dialog created with Tk rather than PyQt6's (rather) limited QInputDialog (or however you'd call it)
2. Use a unified create board prompt across all buttons to remove inconsistencies (such as in MiscWidgets, etc)
3. Allow users to export boards, create them, etc by allowing them to open up the boards directory in their file manager (Explorer on Windows, Finder on macOS, etc)
4. Removes some more imports thanks to the unified dialog (now, the stuff imported in the MiscWidgets script are removed as the function is replaced with the unified function)
5. Fixes a bug I introduced myself, the bug where the build script will put extra literal quotes around the app bundle name on macOS
6. Some README updates

Please check if this works fine and is fine with you. Otherwise, feel free to merge.