### PR TITLE
Always refresh window titles after deleting or doing board-related actions

### DIFF
--- a/build.py
+++ b/build.py
@@ -24,6 +24,11 @@ def run_pyinstaller():
                 '-w',  # Makes it windowed
                 '--icon=icon.ico'
             ]
+        
+        if platform.system() == 'Windows':
+            cmd.extend(['--add-data=schemix/data;data', '--add-data=schemix/core;core'])
+        else:
+            cmd.extend(['--add-data=schemix/data:data', '--add-data=schemix/core:core'])
 
         # Run PyInstaller
         subprocess.check_call(cmd)

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -286,6 +286,9 @@ class MainWindow(QMainWindow):
             shutil.rmtree(self.board_dir, ignore_errors=True)
             self.board_dir = None
             self.check_or_create_board()
+            self.setWindowTitle("Schemix")
+        else:
+            self.setWindowTitle(f"{board_name} - Schemix")
     
     def show_boards_in_fm(self):
         if platform.system() == "Windows":


### PR DESCRIPTION
Fixes the bug where after deleting a board, the window title does not change, and user may think that the old board still exists (I certainly did).