### PR TITLE
Fix splashscreen (mostly)

### DIFF
--- a/schemix/core/Settings.py
+++ b/schemix/core/Settings.py
@@ -25,7 +25,7 @@ class SettingsDock(QDockWidget):
         layout.addRow(QLabel("Theme:"), self.theme_box)
 
         self.showGraph = QCheckBox()
-        self.showGraph.setText("Show Graph Dock by Default ")
+        self.showGraph.setText("Show Graph Dock by Default")
 
         self.funcH = QCheckBox()
         self.funcH.setText("Function Highlighting ")

--- a/schemix/core/stylesheets.py
+++ b/schemix/core/stylesheets.py
@@ -2,8 +2,6 @@ qdockwidget_sub_chap = """
         QDockWidget {
             background-color: #4caf50;
             border: 1px solid #ccc;
-            titlebar-close-icon: url(assets/close.svg);
-            titlebar-normal-icon: url(assets/restore.svg);
         }
 
         QDockWidget::title {

--- a/schemix/core/stylesheets.py
+++ b/schemix/core/stylesheets.py
@@ -2,8 +2,8 @@ qdockwidget_sub_chap = """
         QDockWidget {
             background-color: #4caf50;
             border: 1px solid #ccc;
-            titlebar-close-icon: url(close.svg);
-            titlebar-normal-icon: url(restore.svg);
+            titlebar-close-icon: url(assets/close.svg);
+            titlebar-normal-icon: url(assets/restore.svg);
         }
 
         QDockWidget::title {

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -630,22 +630,23 @@ if __name__ == '__main__':
     splash_label = QLabel()
     splash_pixmap = QPixmap("assets/splash.png")
 
-    splash_label.setPixmap(splash_pixmap)
-    splash_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-    splash_label.setWindowFlags(
-        Qt.WindowType.FramelessWindowHint |
-        Qt.WindowType.SplashScreen |
-        Qt.WindowType.WindowStaysOnTopHint
-    )
-    splash_label.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-    splash_label.setStyleSheet("background: transparent; border: none;")
+    splash_label = QSplashScreen(splash_pixmap)
+    splash_label.show()
+    # splash_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    # splash_label.setWindowFlags(
+    #     Qt.WindowType.FramelessWindowHint |
+    #     Qt.WindowType.SplashScreen |
+    #     Qt.WindowType.WindowStaysOnTopHint
+    # )
+    # splash_label.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+    # splash_label.setStyleSheet("background: transparent; border: none;")
 
-    splash_label.resize(splash_pixmap.size())
+    # splash_label.resize(splash_pixmap.size())
 
-    screen_geometry = app.primaryScreen().availableGeometry()
-    x = (screen_geometry.width() - splash_label.width()) // 2
-    y = (screen_geometry.height() - splash_label.height()) // 2
-    splash_label.move(x, y)
+    # screen_geometry = app.primaryScreen().availableGeometry()
+    # x = (screen_geometry.width() - splash_label.width()) // 2
+    # y = (screen_geometry.height() - splash_label.height()) // 2
+    # splash_label.move(x, y)
 
     # splash_label.show()
     app.processEvents()

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -655,6 +655,6 @@ if __name__ == '__main__':
 
     window = MainWindow()
     window.showMaximized()
-    splash_label.close()
+    splash_label.hide()
 
     sys.exit(app.exec())

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -479,6 +479,7 @@ class MainWindow(QMainWindow):
         help_menu.addAction(version_action)
 
         settings_action = QAction("Settings", self)
+        settings_action.setShortcut("Ctrl+,")
         # Keep Settings in the Help menu (avoid PreferencesRole auto-move)
         settings_action.setMenuRole(QAction.MenuRole.ApplicationSpecificRole)
         settings_action.triggered.connect(self.triggerSettings)

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -12,7 +12,8 @@ from PyQt6.QtGui import QAction, QPixmap, QFont, QTextDocument, QIcon
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QVBoxLayout, QWidget, QLabel, QTextEdit,
     QListWidget, QDockWidget, QInputDialog, QMenu, QStackedWidget,
-    QPushButton, QMessageBox, QToolBar, QComboBox, QFontComboBox, QTabWidget
+    QPushButton, QMessageBox, QToolBar, QComboBox, QFontComboBox, QTabWidget,
+    QSplashScreen
 )
 from pint import UnitRegistry
 

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -627,7 +627,7 @@ if __name__ == '__main__':
     app = QApplication(sys.argv)
     qdarktheme.setup_theme("auto")
 
-    splash_label = QLabel()
+    # splash_label = QLabel()
     splash_pixmap = QPixmap("assets/splash.png")
 
     splash_label = QSplashScreen(splash_pixmap)


### PR DESCRIPTION
Changes:
1. Fix splash screen not showing up
2. Use proper Qt icons rather than custom ones
3. Bind settings to Ctrl+, as it normally is for most programs

See if you approve of these changes; otherwise, feel free to merge.