### PR TITLE
Stop using VirtualStore for appdata (and breaking settings on macOS & Linux)

### DIFF
--- a/schemix/core/Editor.py
+++ b/schemix/core/Editor.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 
@@ -14,6 +13,8 @@ from PyQt6.QtWidgets import (
 from asteval import Interpreter
 from matplotlib import pyplot as plt
 from pint import UnitRegistry
+
+from core import Settings
 
 
 class FunctionHighlighter(QSyntaxHighlighter):
@@ -70,7 +71,7 @@ class RichTextEditor(QTextEdit):
         self.viewport().installEventFilter(self)
         self.inline_conversion = inline  # Show in brackets inline if True
         self.config = self.load_config()
-        self.config_path = "data/config.json"
+        self.config_path = Settings.get_config_path()
 
         if self.config.get("funcH") == "true":
             self.highlighter = FunctionHighlighter(self.document())
@@ -78,16 +79,7 @@ class RichTextEditor(QTextEdit):
             pass
 
     def load_config(self):
-        if os.path.exists("data/config.json"):
-            try:
-                with open("data/config.json", "r") as f:
-                    return json.load(f)
-            except json.JSONDecodeError:
-                pass
-        return {
-            "theme": "Dark",
-            "showGraph": "false"
-        }
+        return Settings.load_config()
 
     def apply_title_format(self):
         cursor = self.textCursor()

--- a/schemix/core/Settings.py
+++ b/schemix/core/Settings.py
@@ -5,6 +5,13 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtCore import Qt
 
+DEFAULT_CONFIG = {
+    "theme": "Dark",
+    "showGraph": "false",
+    "funcH": "true",
+    "wikiSentences": "2"
+}
+
 
 class SettingsDock(QDockWidget):
     def __init__(self, parent=None):

--- a/schemix/core/Settings.py
+++ b/schemix/core/Settings.py
@@ -1,5 +1,7 @@
 import json
 import os
+import sys
+import platform
 from PyQt6.QtWidgets import (
     QDockWidget, QWidget, QFormLayout, QComboBox, QLabel, QCheckBox, QPushButton
 )
@@ -13,14 +15,55 @@ DEFAULT_CONFIG = {
 }
 
 
+def get_appdata_dirs():
+    if platform.system() == "Windows":
+        local_app_data = os.getenv('LOCALAPPDATA')
+    elif platform.system() == "Linux":
+        local_app_data = os.path.expanduser("~/.config")
+    elif platform.system() == "Darwin":
+        local_app_data = os.path.expanduser("~/Library/Application Support")
+    else:
+        print("Unsupported operating system")
+        sys.exit(1)
+
+    local_app_data = os.path.join(local_app_data, "Schemix")
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    return local_app_data, script_dir
+
+
+def get_config_path():
+    local_app_data, _ = get_appdata_dirs()
+    return os.path.normpath(os.path.join(local_app_data, "..", "Schemix-data", "config.json"))
+
+
+def load_config():
+    config_path = get_config_path()
+    if os.path.exists(config_path):
+        try:
+            with open(config_path, "r") as f:
+                config = json.load(f)
+                return {**DEFAULT_CONFIG, **config}
+        except json.JSONDecodeError:
+            pass
+    return DEFAULT_CONFIG.copy()
+
+
+def save_config(config):
+    config_path = get_config_path()
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=4)
+
+
 class SettingsDock(QDockWidget):
     def __init__(self, parent=None):
         super().__init__("Settings", parent)
         self.setAllowedAreas(Qt.DockWidgetArea.RightDockWidgetArea | Qt.DockWidgetArea.LeftDockWidgetArea)
 
-        self.config_path = os.path.join("../data", "config.json")
-       # os.makedirs("../data", exist_ok=True)
-        self.config = self.load_config()
+        self.config_path = get_config_path()
+        os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
+        self.config = load_config()
 
         container = QWidget()
         layout = QFormLayout()
@@ -39,7 +82,7 @@ class SettingsDock(QDockWidget):
 
         self.wiki_box = QComboBox()
         self.wiki_box.addItems(["1", "2", "3", "4", "5", "6", "7"])
-        self.wiki_box.setCurrentText(self.config.get("wikiSentences"))
+        self.wiki_box.setCurrentText(self.config.get("wikiSentences", DEFAULT_CONFIG["wikiSentences"]))
 
         if self.config.get("showGraph") == "false":
             self.showGraph.setChecked(False)
@@ -65,33 +108,18 @@ class SettingsDock(QDockWidget):
         self.apply_config()
 
     def load_config(self):
-        if os.path.exists(self.config_path):
-            try:
-                with open(self.config_path, "r") as f:
-                    return json.load(f)
-            except json.JSONDecodeError:
-                pass
-        return {
-            "theme": "Dark",
-            "showGraph": "false",
-            "funcH": "true"
-        }
+        return load_config()
 
     def save_config(self):
-        with open(self.config_path, "w") as f:
-            json.dump(self.config, f, indent=4)
+        save_config(self.config)
 
     def apply_config(self):
         self.theme_box.setCurrentText(self.config.get("theme", "Dark"))
 
     def apply_settings(self):
 
-        showGraph = "false"
-        if self.showGraph.isChecked():
-            showGraph = "true"
-        else:
-            showGraph = "false"
-
         self.config["theme"] = self.theme_box.currentText()
-        self.config["showGraph"] = showGraph
+        self.config["showGraph"] = "true" if self.showGraph.isChecked() else "false"
+        self.config["funcH"] = "true" if self.funcH.isChecked() else "false"
+        self.config["wikiSentences"] = self.wiki_box.currentText()
         self.save_config()

--- a/schemix/data/config.json
+++ b/schemix/data/config.json
@@ -1,6 +1,0 @@
-{
-    "theme": "Light",
-    "showGraph": "false",
-    "funcH": "true",
-    "wikiSentences": "2"
-}

--- a/schemix/main.py
+++ b/schemix/main.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 import sys
@@ -31,16 +30,7 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("Schemix")
         self.setGeometry(100, 100, 1200, 800)
-        if platform.system() == "Windows":
-            local_app_data = os.getenv('LOCALAPPDATA')
-        elif platform.system() == "Linux":
-            local_app_data = os.path.expanduser("~/.config")
-        elif platform.system() == "Darwin":
-            local_app_data = os.path.expanduser("~/Library/Application Support")
-        else:
-            print("Unsupported operating system")
-            sys.exit(1)
-        local_app_data = os.path.join(local_app_data, "Schemix")
+        local_app_data, _ = Settings.get_appdata_dirs()
         self.base_dir = local_app_data
         os.makedirs(self.base_dir, exist_ok=True)
         self.board_dir = None
@@ -70,8 +60,9 @@ class MainWindow(QMainWindow):
 
         self.toolbar = QToolBar("Formatting")
 
+        self.config_path = Settings.get_config_path()
+        os.makedirs(os.path.dirname(self.config_path), exist_ok=True)
         self.config = self.load_config()
-        self.config_path = "data/config.json"
 
         self.subjects_dock = QDockWidget("Subjects")
 
@@ -144,16 +135,7 @@ class MainWindow(QMainWindow):
             self.refresh_subjects()
 
     def load_config(self):
-        if os.path.exists("data/config.json"):
-            try:
-                with open("data/config.json", "r") as f:
-                    return json.load(f)
-            except json.JSONDecodeError:
-                pass
-        return {
-            "theme": "Dark",
-            "showGraph": "false"
-        }
+        return Settings.load_config()
 
     def add_chapter(self):
         if not self.current_subject:


### PR DESCRIPTION
Currently, the settings and other non-notes settings are stored in the virtualstore on Windows and break when written on macOS & Linux. This solves that by storing it in the system configuration (localappdata) folder.